### PR TITLE
Add Gemini 3.5 Flash support and set as default

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ func main() {
 	ctx := context.Background()
 
 	// Create a new client with your API key
-	// By default, it will use "gemini-3-flash-preview" (see constants.go).
+	// By default, it will use "gemini-3.5-flash" (see constants.go).
 	// For higher reasoning quality, use WithModelName("gemini-3.1-pro-preview").
 	// Google Search Tool is enabled by default.
 	client, err := search.NewClient(ctx, apiKey)
@@ -178,7 +178,7 @@ var temp float32 = 0.2
 client, err := search.NewClient(
     ctx,
     "your-api-key",
-    search.WithModelName("gemini-3.1-pro-preview"), // or "gemini-3-flash-preview" for faster/cheaper
+    search.WithModelName("gemini-3.1-pro-preview"), // or "gemini-3.5-flash" for faster/cheaper
     search.WithDefaultTemperature(temp),
 )
 ```
@@ -253,13 +253,13 @@ The helper functions in `errors.go` (e.g., `IsAPIError`, `IsContentBlockedError`
 
 The library supports several configuration options through the functional options pattern passed to `NewClient` (see `options.go` for all available options):
 
-- `WithModelName(name string)`: Specifies which Gemini model to use (e.g., `"gemini-3-flash-preview"` or `"gemini-3.1-pro-preview"`).
+- `WithModelName(name string)`: Specifies which Gemini model to use (e.g., `"gemini-3.5-flash"` or `"gemini-3.1-pro-preview"`).
 - `WithDefaultTemperature(temp float32)`: Sets the default generation temperature (0.0 for more factual, higher for more creative).
 - `WithDefaultMaxOutputTokens(tokens int32)`: Sets the default maximum number of tokens to generate.
 - `WithDefaultTopK(k int32)`: Sets the default TopK sampling parameter.
 - `WithDefaultTopP(p float32)`: Sets the default TopP (nucleus) sampling parameter.
 - `WithDefaultSafetySettings(settings []*SafetySetting)`: Sets default safety settings.
-- `WithDefaultThinkingConfig(tc *ThinkingConfig)`: Controls the model's thinking behavior. For Gemini 3/3.1 series models, use `ThinkingLevel` (`ThinkingLevelMinimal`, `ThinkingLevelLow`, `ThinkingLevelMedium`, `ThinkingLevelHigh`). For Gemini 2.5 series models, use `ThinkingBudget` (set to `0` to disable thinking).
+- `WithDefaultThinkingConfig(tc *ThinkingConfig)`: Controls the model's thinking behavior. For Gemini 3/3.1/3.5 series models, use `ThinkingLevel` (`ThinkingLevelMinimal`, `ThinkingLevelLow`, `ThinkingLevelMedium`, `ThinkingLevelHigh`). For Gemini 2.5 series models, use `ThinkingBudget` (set to `0` to disable thinking).
 - `WithHTTPClient(client *http.Client)`: Provides a custom HTTP client.
 - `WithRequestTimeout(timeout time.Duration)`: Sets a default timeout for API requests.
 - `WithGoogleSearchToolDisabled(disabled bool)`: Allows disabling the Google Search Tool globally for the client.

--- a/client.go
+++ b/client.go
@@ -49,7 +49,7 @@ type Client struct {
 	config                  ClientConfig                 // Resolved configuration after applying options
 	genaiClient             *genai.Client                // Underlying client from the official Google AI Go SDK
 	httpClient              *http.Client                 // HTTP client for non-API requests like redirection resolving
-	defaultModel            string                       // Default model name (e.g., "gemini-3-flash-preview")
+	defaultModel            string                       // Default model name (e.g., "gemini-3.5-flash")
 	defaultGenContentConfig *genai.GenerateContentConfig // Default generation configuration
 	userAgent               string                       // Combined user-agent string
 }

--- a/cmd/gemini-search/main.go
+++ b/cmd/gemini-search/main.go
@@ -12,7 +12,7 @@ import (
 	"github.com/urfave/cli/v3"
 )
 
-const defaultModel = "gemini-3-flash-preview"
+const defaultModel = "gemini-3.5-flash"
 
 func parseThinkingLevel(s string) (search.ThinkingLevel, error) {
 	switch strings.ToUpper(s) {
@@ -47,7 +47,7 @@ func main() {
 			&cli.StringFlag{
 				Name:    "thinking-level",
 				Aliases: []string{"t"},
-				Usage:   "Thinking level for the model (minimal, low, medium, high). For Gemini 3/3.1 series models (e.g., gemini-3-flash-preview, gemini-3.1-pro-preview).",
+				Usage:   "Thinking level for the model (minimal, low, medium, high). For Gemini 3/3.1/3.5 series models (e.g., gemini-3.5-flash, gemini-3.1-pro-preview, gemini-3-flash-preview).",
 			},
 			&cli.BoolFlag{
 				Name:    "verbose",

--- a/config.go
+++ b/config.go
@@ -11,7 +11,7 @@ type ClientConfig struct {
 	// This field is mandatory.
 	APIKey string
 
-	// ModelName is the default Gemini model to be used for requests (e.g., "gemini-3-flash-preview").
+	// ModelName is the default Gemini model to be used for requests (e.g., "gemini-3.5-flash").
 	// Can be overridden per request via GenerationParams.
 	ModelName string
 

--- a/constants.go
+++ b/constants.go
@@ -16,9 +16,9 @@ const (
 // Default configuration values for the client.
 const (
 	// DefaultModelName is the default Gemini model used if not specified by the user.
-	// Gemini Flash is chosen for its balance of speed and cost for grounded search.
+	// Gemini 3.5 Flash is chosen for its balance of speed and cost for grounded search.
 	// For higher reasoning quality, consider using "gemini-3.1-pro-preview" via WithModelName.
-	DefaultModelName = "gemini-3-flash-preview"
+	DefaultModelName = "gemini-3.5-flash"
 
 	// DefaultTemperature for grounded search tasks.
 	// 0.0f is generally recommended for factuality and to minimize hallucinations.

--- a/examples/simple/main.go
+++ b/examples/simple/main.go
@@ -67,7 +67,7 @@ func main() {
 
 	// Initialize the client.
 	client, err := search.NewClient(ctx, apiKey,
-		search.WithModelName("gemini-3-flash-preview"),
+		search.WithModelName("gemini-3.5-flash"),
 		search.WithNoRedirection(),
 	)
 	if err != nil {

--- a/options.go
+++ b/options.go
@@ -93,7 +93,7 @@ func WithDefaultSafetySettings(settings []*SafetySetting) ClientOption {
 // WithDefaultThinkingConfig sets the default thinking configuration for the client.
 // If nil is passed, the model's built-in thinking behavior is used as-is.
 //
-// For Gemini 3/3.1 series models (e.g., gemini-3-flash-preview, gemini-3.1-pro-preview),
+// For Gemini 3/3.1/3.5 series models (e.g., gemini-3.5-flash, gemini-3.1-pro-preview, gemini-3-flash-preview),
 // use ThinkingLevel:
 //
 //	search.WithDefaultThinkingConfig(&search.ThinkingConfig{

--- a/types.go
+++ b/types.go
@@ -58,7 +58,7 @@ const (
 
 // ThinkingConfig controls the Gemini model's thinking behavior.
 //
-// For Gemini 3/3.1 series models (e.g., gemini-3-flash-preview, gemini-3.1-pro-preview),
+// For Gemini 3/3.1/3.5 series models (e.g., gemini-3.5-flash, gemini-3.1-pro-preview, gemini-3-flash-preview),
 // use ThinkingLevel (ThinkingLevelMinimal, ThinkingLevelLow, ThinkingLevelMedium, ThinkingLevelHigh).
 // For Gemini 2.5 series models, use ThinkingBudget (numeric token count).
 // When this config is nil (the default), the model's built-in thinking behavior is used as-is.
@@ -71,7 +71,7 @@ type ThinkingConfig struct {
 	// Recommended for Gemini 2.5 series models.
 	ThinkingBudget *int32 `json:"thinking_budget,omitempty"`
 	// ThinkingLevel controls the level of thinking the model should perform.
-	// Recommended for Gemini 3/3.1 series models.
+	// Recommended for Gemini 3/3.1/3.5 series models.
 	ThinkingLevel ThinkingLevel `json:"thinking_level,omitempty"`
 }
 


### PR DESCRIPTION
## Summary
- 既定モデルを `gemini-3-flash-preview` から `gemini-3.5-flash` に変更(ライブラリ定数・CLI デフォルト・サンプル・README)
- `ThinkingLevel` 関連の docstring を Gemini 3 / 3.1 / 3.5 系をカバーするよう更新

## Background
2026-05-19 リリースの Gemini 3.5 Flash(stable model ID: `gemini-3.5-flash`)に対応。`thinking_level` API は Gemini 3 系と同じ仕組みのため、SDK 周辺コードの変更は不要で、デフォルト切り替えとドキュメント更新のみ行いました。

参考:
- https://deepmind.google/models/gemini/flash/
- https://ai.google.dev/gemini-api/docs/whats-new-gemini-3.5

## Test plan
- [x] \`go build ./...\` が通ること
- [ ] \`gemini-search \"...\"\` を実行し、デフォルトで gemini-3.5-flash が使われることを確認
- [ ] \`--thinking-level medium\` 等を指定した場合に正しく反映されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)