### PR TITLE
Bump LibraryVersion to 2.1.0

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -10,7 +10,7 @@ const (
 
 	// LibraryVersion is the current version of this library.
 	// Follow semantic versioning (https://semver.org/).
-	LibraryVersion = "0.1.0"
+	LibraryVersion = "2.1.0"
 )
 
 // Default configuration values for the client.


### PR DESCRIPTION
## Summary
- `LibraryVersion` 定数を `0.1.0` → `2.1.0` に更新

## Note
Go module パス (`go.mod`) は変更していません。仮にこの版をリリースタグ `v2.x.x` として切る場合、Go modules 規約上 module path を `/v2` に変更する必要があります(現状の最新 tag は `v1.4.0`)。意図と異なれば redirect してください。

🤖 Generated with [Claude Code](https://claude.com/claude-code)