### PR TITLE
Migrate module path to /v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # go-gemini-grounded-search
 
-[![Go Reference](https://pkg.go.dev/badge/github.com/cnosuke/go-gemini-grounded-search.svg)](https://pkg.go.dev/github.com/cnosuke/go-gemini-grounded-search)
+[![Go Reference](https://pkg.go.dev/badge/github.com/cnosuke/go-gemini-grounded-search/v2.svg)](https://pkg.go.dev/github.com/cnosuke/go-gemini-grounded-search/v2)
 [![Go Report Card](https://goreportcard.com/badge/github.com/cnosuke/go-gemini-grounded-search)](https://goreportcard.com/report/github.com/cnosuke/go-gemini-grounded-search)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
@@ -23,7 +23,7 @@ A Go client library for Google's Gemini API, focusing on leveraging its Google S
 ## Installation
 
 ```bash
-go get github.com/cnosuke/go-gemini-grounded-search
+go get github.com/cnosuke/go-gemini-grounded-search/v2
 ```
 
 ### CLI
@@ -33,7 +33,7 @@ go get github.com/cnosuke/go-gemini-grounded-search
 make install        # installs gemini-search to $GOBIN
 
 # or directly
-go install github.com/cnosuke/go-gemini-grounded-search/cmd/gemini-search@latest
+go install github.com/cnosuke/go-gemini-grounded-search/v2/cmd/gemini-search@latest
 ```
 
 ## Quick Start
@@ -47,7 +47,7 @@ import (
 	"log"
 	"os"
 
-	search "github.com/cnosuke/go-gemini-grounded-search"
+	search "github.com/cnosuke/go-gemini-grounded-search/v2"
 )
 
 func main() {
@@ -114,7 +114,7 @@ import (
 	"os"
 	"time"
 
-	search "github.com/cnosuke/go-gemini-grounded-search"
+	search "github.com/cnosuke/go-gemini-grounded-search/v2"
 )
 
 func main() {
@@ -163,7 +163,7 @@ func main() {
 
 ## API Reference
 
-For detailed API documentation, see the [Go Reference](https://pkg.go.dev/github.com/cnosuke/go-gemini-grounded-search).
+For detailed API documentation, see the [Go Reference](https://pkg.go.dev/github.com/cnosuke/go-gemini-grounded-search/v2).
 
 ### Client
 

--- a/client.go
+++ b/client.go
@@ -37,7 +37,7 @@ import (
 	"strings"
 	"time"
 
-	ierrors "github.com/cnosuke/go-gemini-grounded-search/internal/errors"
+	ierrors "github.com/cnosuke/go-gemini-grounded-search/v2/internal/errors"
 	"google.golang.org/genai"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"

--- a/cmd/gemini-search/main.go
+++ b/cmd/gemini-search/main.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"time"
 
-	search "github.com/cnosuke/go-gemini-grounded-search"
+	search "github.com/cnosuke/go-gemini-grounded-search/v2"
 	"github.com/urfave/cli/v3"
 )
 

--- a/examples/simple/main.go
+++ b/examples/simple/main.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"time"
 
-	search "github.com/cnosuke/go-gemini-grounded-search"
+	search "github.com/cnosuke/go-gemini-grounded-search/v2"
 )
 
 func buildQuery(s string) string {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/cnosuke/go-gemini-grounded-search
+module github.com/cnosuke/go-gemini-grounded-search/v2
 
 go 1.24.0
 

--- a/options.go
+++ b/options.go
@@ -4,7 +4,7 @@ import (
 	"net/http"
 	"time"
 
-	ierrors "github.com/cnosuke/go-gemini-grounded-search/internal/errors"
+	ierrors "github.com/cnosuke/go-gemini-grounded-search/v2/internal/errors"
 )
 
 // ClientOption is a function type used to apply configuration options to a ClientConfig.


### PR DESCRIPTION
## Summary
- \`go.mod\` の module path に \`/v2\` サフィックスを追加 (\`github.com/cnosuke/go-gemini-grounded-search/v2\`)
- 内部 import (\`internal/errors\`), examples, CLI, README を \`/v2\` パスに更新

## Background
PR #6 で \`LibraryVersion\` を 2.1.0 に bump し \`v2.1.0\` タグも打ちましたが、Go modules 規約上 major version 2+ では module path に \`/v2\` サフィックスが必須です。これが無いと \`go get @v2.1.0\` が \`invalid version: should be v0 or v1\` で失敗します。本 PR で正式に v2 モジュールに移行します。

## Test plan
- [x] \`go build ./...\` 成功
- [ ] マージ後、既存タグ \`v2.1.0\` を削除して再作成、\`go get github.com/cnosuke/go-gemini-grounded-search/v2@v2.1.0\` で取得できることを確認

## Breaking change
利用側は import path を \`github.com/cnosuke/go-gemini-grounded-search\` → \`github.com/cnosuke/go-gemini-grounded-search/v2\` に書き換える必要があります。

🤖 Generated with [Claude Code](https://claude.com/claude-code)