### PR TITLE
Correct LibraryVersion to 1.5.0

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -10,7 +10,7 @@ const (
 
 	// LibraryVersion is the current version of this library.
 	// Follow semantic versioning (https://semver.org/).
-	LibraryVersion = "2.1.0"
+	LibraryVersion = "1.5.0"
 )
 
 // Default configuration values for the client.


### PR DESCRIPTION
## Summary
- \`LibraryVersion\` を \`2.1.0\` → \`1.5.0\` に訂正

## Background
PR #6 で 2.1.0 に bump し v2.1.0 タグも打ちましたが、本リリースの変更内容(デフォルトモデル更新のみ、公開 API に破壊変更なし)を SemVer で見ると MINOR bump が妥当でした。v2 にすると Go modules の \`/v2\` パス移行が必要になり、利用者の import を強制書き換えさせるコストに見合いません。

v2.1.0 タグは削除済み(local & remote)。本 PR マージ後に \`v1.5.0\` を打ち直します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)